### PR TITLE
Refactor caching architecture with DistributedBackedRepository

### DIFF
--- a/StackExchange.Redis.DistributedRepository/DistributedBackedRepository.cs
+++ b/StackExchange.Redis.DistributedRepository/DistributedBackedRepository.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis.DistributedRepository.Models;
 using StackExchange.Redis.DistributedRepository.Telemetry;
@@ -12,7 +13,7 @@ using static StackExchange.Redis.DistributedRepository.Extensions.RepositoryExte
 [assembly: InternalsVisibleTo("StackExchange.Redis.DistributedRepository.Banchmark")]
 namespace StackExchange.Redis.DistributedRepository;
 
-public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, IDistributedRepository<T> where T : class
+public class DistributedBackedRepository<T> : RepositoryBase<T>, IDistributedCache, IDistributedRepository<T> where T : class
 {
 	protected static string InstanceId = Guid.NewGuid().ToString();
 
@@ -33,6 +34,14 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 	}
 
 	/// <summary>
+	/// Base key in memory full list
+	/// </summary>
+	protected string MemoryListKey
+	{
+		get => $"{BaseKey}:list";
+	}
+
+	/// <summary>
 	/// Key selector for the repository's entity
 	/// </summary>
 	public readonly Func<T, string> KeySelector;
@@ -40,22 +49,26 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 	private readonly IDatabase _database;
 	private readonly IRedisDatabase _redisDatabase;
 	private readonly ISubscriber _subscriber;
+	private readonly IMemoryCache _memoryCache;
 	private readonly IRepositoryMetrics? _metrics;
-	private readonly ILogger<DistributedRepository<T>>? _logger;
+	private readonly ILogger<DistributedBackedRepository<T>>? _logger;
 
-	public DistributedRepository(
+	public DistributedBackedRepository(
 		IRedisClient redis,
+		IMemoryCache memoryCache,
 		Func<T, string> keySelector,
 		IRepositoryMetrics? metrics = null,
-		ILogger<DistributedRepository<T>>? logger = null)
+		ILogger<DistributedBackedRepository<T>>? logger = null)
 	{
 		_redisDatabase = redis.GetDefaultDatabase();
 		_database = _redisDatabase.Database;
 		_subscriber = _redisDatabase.Database.Multiplexer.GetSubscriber();
 		_subscriber.Subscribe(BaseKey, ItemUpdatedHandler);
+		_memoryCache = memoryCache;
 		_metrics = metrics;
 		_logger = logger;
 		KeySelector = keySelector;
+		Task.Run(RebakeAll).ConfigureAwait(true);
 	}
 
 	#region add
@@ -77,6 +90,7 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 
 			string fqk = this.FQK(key);
 			T result = await AddRedis(key, item);
+			MemoryAdd(item, fqk);
 			_subscriber.Publish(BaseKey, GenerateMessage(MessageType.Created, key));
 			return result;
 		}
@@ -98,6 +112,7 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 	public async Task AddRangeAsync(IEnumerable<T> range)
 	{
 		await RedisAddRange(range);
+		MemoryAddRange(range);
 	}
 
 	protected async Task RedisAddRange(IEnumerable<T> range)
@@ -127,6 +142,22 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		}
 	}
 
+	protected void MemoryAddRange(IEnumerable<T> range)
+	{
+		_memoryCache.TryGetValue(MemoryListKey, out List<T>? items);
+		if (items is null)
+		{
+			items = new List<T>();
+			_memoryCache.Set(MemoryListKey, items);
+		}
+		items.AddRange(range);
+		foreach (var item in range)
+		{
+			string key = KeySelector.Invoke(item);
+			_memoryCache.Set(this.FQK(key), item);
+		}
+	}
+
 	protected async Task<T> AddRedis(string key, T item)
 	{
 		using Activity? activity = ActivitySourceProvider.StartActivity("repo.add.redis", key: key);
@@ -149,6 +180,18 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		{
 			_metrics?.ObserveDuration("repo.add.redis", sw.Elapsed);
 		}
+	}
+	protected void MemoryAdd(T item, string fqk)
+	{
+		_memoryCache.TryGetValue(MemoryListKey, out List<T>? items);
+		if (items is null)
+		{
+			items = new List<T>();
+			_memoryCache.Set(MemoryListKey, items);
+		}
+		items.Add(item);
+		_memoryCache.Set(fqk, item);
+
 	}
 	#endregion
 
@@ -173,6 +216,7 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		if (poped is null)
 			return null;
 		await RemoveRedis(key);
+		RemoveMemory(key);
 		_subscriber.Publish(BaseKey, GenerateMessage(MessageType.Deleted, key));
 		return poped;
 	}
@@ -184,6 +228,15 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		transaction.SetRemoveAsync(BaseKeyTracker, key);
 		await transaction.ExecuteAsync();
 	}
+	protected void RemoveMemory(string key)
+	{
+		_memoryCache.TryGetValue(MemoryListKey, out List<T>? items);
+		if (items is null)
+			return;
+		items.RemoveAll(x => KeySelector.Invoke(x) == key);
+
+		_memoryCache.Remove(this.FQK(key));
+	}
 	#endregion
 
 	/// <inheritdoc/>
@@ -193,12 +246,18 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		Stopwatch? sw = Stopwatch.StartNew();
 		try
 		{
+			if (_memoryCache.TryGetValue(this.FQK(Key), out T? item))
+			{
+				return item;
+			}
+
 			if (_database.HashExists(BaseKey, Key))
 			{
 				string? value = _database.HashGet(BaseKey, Key);
 				if (string.IsNullOrEmpty(value))
 					return null;
-				T? item = JsonSerializer.Deserialize<T?>(value);
+				item = JsonSerializer.Deserialize<T?>(value);
+				_memoryCache.Set(this.FQK(Key), item);
 				return item;
 			}
 		}
@@ -234,12 +293,18 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		Stopwatch? sw = Stopwatch.StartNew();
 		try
 		{
+			if (_memoryCache.TryGetValue(this.FQK(Key), out T? item))
+			{
+				return item;
+			}
+
 			if (_database.HashExists(BaseKey, Key))
 			{
 				string? value = await _database.HashGetAsync(BaseKey, Key);
 				if (string.IsNullOrEmpty(value))
 					return null;
-				T? item = JsonSerializer.Deserialize<T>(value);
+				item = JsonSerializer.Deserialize<T>(value);
+				_memoryCache.Set(this.FQK(Key), item);
 				return item;
 			}
 		}
@@ -271,21 +336,84 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 	/// <inheritdoc/>
 	public async Task<IEnumerable<T>> GetAsync()
 	{
-		HashEntry[]? objects = await _database.HashGetAllAsync(BaseKey);
+		bool fetchedFromMemory = _memoryCache.TryGetValue(MemoryListKey, out List<T>? items);
+		if (!fetchedFromMemory || items is null)
+		{
+			HashEntry[]? objects = await _database.HashGetAllAsync(BaseKey);
 
-		IDictionary<string, T?> values = objects.ToDictionary(x => x.Name.ToString(), x => JsonSerializer.Deserialize<T>(x.Value));
+			IDictionary<string, T?> values = objects.ToDictionary(x => x.Name.ToString(), x => JsonSerializer.Deserialize<T>(x.Value));
 
-		return values.Where(x => x.Value is not null).Select(x => x.Value);
+			_memoryCache.Set(
+				MemoryListKey,
+				values.Values.ToList()
+			);
+
+			foreach (KeyValuePair<string, T?> item in values)
+			{
+				if (item.Value is null)
+					continue;
+
+				_memoryCache.Set(this.FQK(item.Key), item.Value);
+			}
+			return values.Where(x => x.Value is not null).Select(x => x.Value);
+		}
+
+		return items;
 	}
 
 	/// <inheritdoc/>
 	public IEnumerable<T> Get()
 	{
-		HashEntry[]? objects = _database.HashGetAll(BaseKey);
+		bool fetchedFromMemory = _memoryCache.TryGetValue(MemoryListKey, out List<T>? items);
+		if (!fetchedFromMemory || items is null)
+		{
+			HashEntry[]? objects = _database.HashGetAll(BaseKey);
 
-		IDictionary<string, T?> values = objects.ToDictionary(x => x.Name.ToString(), x => JsonSerializer.Deserialize<T>(x.Value));
+			IDictionary<string, T?> values = objects.ToDictionary(x => x.Name.ToString(), x => JsonSerializer.Deserialize<T>(x.Value));
 
-		return values.Where(x => x.Value is not null).Select(x => x.Value);
+			_memoryCache.Set(
+				MemoryListKey,
+				values.Values.ToList()
+			);
+
+			foreach (KeyValuePair<string, T?> item in values)
+			{
+				if (item.Value is null)
+					continue;
+
+				_memoryCache.Set(this.FQK(item.Key), item.Value);
+			}
+			return values.Where(x => x.Value is not null).Select(x => x.Value);
+		}
+
+		return items;
+	}
+
+	/// <inheritdoc/>
+	public async Task RebakeAll()
+	{
+		using Activity? activity = ActivitySourceProvider.StartActivity("repo.rebake");
+		Stopwatch? sw = Stopwatch.StartNew();
+		try
+		{
+
+			RedisValue[]? keys = _database.SetMembers(BaseKeyTracker);
+
+			foreach (var item in keys)
+			{
+				MemoryAdd(await GetAsync(item), this.FQK(item.ToString()));
+			}
+		}
+		catch (Exception ex)
+		{
+			_logger?.LogError(ex, "Error rebaking all items in repository");
+			throw;
+		}
+		finally
+		{
+			_metrics?.ObserveDuration("repo.rebake", sw.Elapsed);
+			activity?.Stop();
+		}
 	}
 
 	/// <inheritdoc/>
@@ -300,6 +428,8 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 			transaction.KeyDeleteAsync(BaseKeyTracker);
 			await transaction.ExecuteAsync();
 			await _subscriber.PublishAsync(BaseKey, GenerateMessage(MessageType.Purged, null));
+			MemoryPurge();
+			await RebakeAll();
 		}
 		catch (Exception ex)
 		{
@@ -311,6 +441,22 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 			_metrics?.ObserveDuration("repo.purge", sw.Elapsed);
 			activity?.Stop();
 		}
+	}
+
+	public void MemoryPurge()
+	{
+		List<T>? items = _memoryCache.Get<List<T>>(MemoryListKey);
+		if (items is null)
+			return;
+		foreach (var item in items)
+		{
+			_memoryCache.Remove(this.FQK(KeySelector.Invoke(item)));
+		}
+
+		_memoryCache.Set(
+			MemoryListKey,
+			new List<T>()
+		);
 	}
 
 	/// <inheritdoc/>
@@ -332,10 +478,14 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 			transaction.SetAddAsync(BaseKeyTracker, toAdd.ToArray());
 			await transaction.ExecuteAsync();
 
+			foreach (RedisValue key in keys)
+			{
+				MemoryAdd(await GetAsync(key), this.FQK(key.ToString()));
+			}
 		}
 		catch (Exception ex)
 		{
-			_logger?.LogError(ex, "Error rebuilding all items in repository");
+			_logger?.LogError(ex, "Error rebaking all items in repository");
 			throw;
 		}
 		finally
@@ -354,7 +504,38 @@ public class DistributedRepository<T> : RepositoryBase<T>, IDistributedCache, ID
 		if (message.i == InstanceId)
 			return;
 
-		return;
+		switch (message.type)
+		{
+			case MessageType.Created:
+				if (string.IsNullOrEmpty(message.item))
+					return;
+				T? item = Get(message.item);
+				if (item is null) return;
+				MemoryAdd(item, this.FQK(message.item));
+				break;
+			case MessageType.Updated:
+				if (string.IsNullOrEmpty(message.item))
+					return;
+				T? item2 = Get(message.item);
+				if (item2 is null) return;
+				_memoryCache.Set(this.FQK(message.item), item2);
+				break;
+			case MessageType.Deleted:
+				if (string.IsNullOrEmpty(message.item))
+					return;
+				RemoveMemory(message.item);
+				break;
+			case MessageType.Purged:
+				List<string>? keys = _memoryCache.Get<List<string>>(BaseKeyTracker);
+				if (keys is null || !keys.Any()) return;
+				foreach (var key in keys)
+				{
+					_memoryCache.Remove(key);
+				}
+				break;
+			default:
+				break;
+		}
 	}
 
 	internal string GenerateMessage(MessageType messageType, string? resourceKey)

--- a/StackExchange.Redis.DistributedRepository/Extensions/DI/ServiceCollectionExtensions.cs
+++ b/StackExchange.Redis.DistributedRepository/Extensions/DI/ServiceCollectionExtensions.cs
@@ -22,7 +22,27 @@ public static class ServiceCollectionExtensions
 			IMemoryCache memoryCache = provider.GetRequiredService<IMemoryCache>();
 			IRepositoryMetrics? metrics = provider.GetService<IRepositoryMetrics>();
 			ILogger<DistributedRepository<T>>? logger = provider.GetService<ILogger<DistributedRepository<T>>>();
-			return new DistributedRepository<T>(redis, memoryCache, keySelector, metrics, logger);
+			return new DistributedRepository<T>(redis, keySelector, metrics, logger);
+		});
+		return services;
+	}
+
+	/// <summary>
+	/// Adds a distributed repository with memory mirror to the service collection
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="services"></param>
+	/// <param name="keySelector"></param>
+	/// <returns></returns>
+	public static IServiceCollection AddDistributedBackedRepository<T>(this IServiceCollection services, Func<T, string> keySelector) where T : class
+	{
+		services.AddScoped<IDistributedRepository<T>>((provider) =>
+		{
+			IRedisClient redis = provider.GetRequiredService<IRedisClient>();
+			IMemoryCache memoryCache = provider.GetRequiredService<IMemoryCache>();
+			IRepositoryMetrics? metrics = provider.GetService<IRepositoryMetrics>();
+			ILogger<DistributedBackedRepository<T>>? logger = provider.GetService<ILogger<DistributedBackedRepository<T>>>();
+			return new DistributedBackedRepository<T>(redis, memoryCache, keySelector, metrics, logger);
 		});
 		return services;
 	}
@@ -33,7 +53,7 @@ public static class ServiceCollectionExtensions
 		{
 			IRedisClient redis = provider.GetRequiredService<IRedisClient>();
 			IMemoryCache memoryCache = provider.GetRequiredService<IMemoryCache>();
-			return new DistributedRepository<T>(redis, memoryCache, keySelector);
+			return new DistributedBackedRepository<T>(redis, memoryCache, keySelector);
 		});
 		return services;
 	}

--- a/StackExchange.Redis.DistributedRepository/Extensions/RepositoryExtensions.cs
+++ b/StackExchange.Redis.DistributedRepository/Extensions/RepositoryExtensions.cs
@@ -13,6 +13,16 @@ internal static class RepositoryExtensions
 	/// <summary>
 	/// Returns fully qualified key
 	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	/// <param name="repo"></param>
+	/// <param name="key"></param>
+	/// <returns></returns>
+	public static string FQK<T>(this DistributedBackedRepository<T> repo, string key) where T : class =>
+
+		$"{repo.BaseKey}:{key}";
+	/// <summary>
+	/// Returns fully qualified key
+	/// </summary>
 	/// <param name="item"></param>
 	/// <returns></returns>
 	private static string FQK<T>(this DistributedRepository<T> repo, T item) where T : class => 

--- a/StackExchange.Redis.DistributedRepository/IDistributedRepository.cs
+++ b/StackExchange.Redis.DistributedRepository/IDistributedRepository.cs
@@ -71,7 +71,6 @@ public interface IDistributedRepository<T> where T : class
 	/// </summary>
 	/// <returns></returns>
 	Task Purge();
-	Task RebakeAll();
 
 	/// <summary>
 	/// Rebuilds the repository, syncing with distributed cache with in-memory, taking distributed data container as source of truth


### PR DESCRIPTION
This commit introduces the `DistributedBackedRepository` class, which implements the `IDistributedRepository<T>` interface and manages a distributed cache with an in-memory mirror. The `IMemoryCache` dependency has been removed from `DistributedRepository`, and memory management methods have been centralized in the new class.

Additionally, the `RebakeAll` and `Purge` methods have been updated to utilize the new memory management methods. The `ServiceCollectionExtensions` class now returns an instance of `DistributedBackedRepository`, and the `IDistributedRepository<T>` interface has been modified to remove the `RebakeAll` method. A new `FQK` method has been added to `RepositoryExtensions` for generating fully qualified keys.

Overall, this refactor improves the code structure and separation of concerns between distributed and in-memory caching.